### PR TITLE
Separate literals from runtime representations

### DIFF
--- a/lib/javascript/interpreter.rb
+++ b/lib/javascript/interpreter.rb
@@ -62,7 +62,7 @@ module Javascript
         when Assignment         then evaluate_assignment(expression)
         when StringLiteral      then evaluate_string_literal(expression)
         when NumberLiteral      then evaluate_number_literal(expression)
-        when Boolean            then evaluate_boolean(expression)
+        when BooleanLiteral     then evaluate_boolean_literal(expression)
         when UnaryOperation     then evaluate_unary_operation(expression)
         when BinaryOperation    then evaluate_binary_operation(expression)
         when Parenthetical      then evaluate_parenthetical(expression)
@@ -109,8 +109,8 @@ module Javascript
         Number.new(literal.value)
       end
 
-      def evaluate_boolean(boolean)
-        boolean
+      def evaluate_boolean_literal(literal)
+        Boolean.wrap(literal.value)
       end
 
       def evaluate_unary_operation(operation)

--- a/lib/javascript/interpreter.rb
+++ b/lib/javascript/interpreter.rb
@@ -60,7 +60,7 @@ module Javascript
         when FunctionCall       then evaluate_function_call(expression)
         when Identifier         then evaluate_identifier(expression)
         when Assignment         then evaluate_assignment(expression)
-        when String             then evaluate_string(expression)
+        when StringLiteral      then evaluate_string_literal(expression)
         when Number             then evaluate_number(expression)
         when Boolean            then evaluate_boolean(expression)
         when UnaryOperation     then evaluate_unary_operation(expression)
@@ -101,8 +101,8 @@ module Javascript
         end
       end
 
-      def evaluate_string(string)
-        string
+      def evaluate_string_literal(literal)
+        String.new(literal.value)
       end
 
       def evaluate_number(number)

--- a/lib/javascript/interpreter.rb
+++ b/lib/javascript/interpreter.rb
@@ -61,7 +61,7 @@ module Javascript
         when Identifier         then evaluate_identifier(expression)
         when Assignment         then evaluate_assignment(expression)
         when StringLiteral      then evaluate_string_literal(expression)
-        when Number             then evaluate_number(expression)
+        when NumberLiteral      then evaluate_number_literal(expression)
         when Boolean            then evaluate_boolean(expression)
         when UnaryOperation     then evaluate_unary_operation(expression)
         when BinaryOperation    then evaluate_binary_operation(expression)
@@ -105,8 +105,8 @@ module Javascript
         String.new(literal.value)
       end
 
-      def evaluate_number(number)
-        number
+      def evaluate_number_literal(literal)
+        Number.new(literal.value)
       end
 
       def evaluate_boolean(boolean)

--- a/lib/javascript/parser.rb
+++ b/lib/javascript/parser.rb
@@ -2,6 +2,7 @@ module Javascript
   Assignment          = Struct.new(:identifier, :value)
   BinaryOperation     = Struct.new(:operator, :left_hand_side, :right_hand_side)
   Block               = Struct.new(:body)
+  BooleanLiteral      = Struct.new(:value, keyword_init: true)
   ExpressionStatement = Struct.new(:expression)
   FunctionCall        = Struct.new(:callee, :arguments)
   FunctionDefinition  = Struct.new(:name, :parameters, :body)
@@ -326,11 +327,11 @@ module Javascript
       end
 
       def parse_true
-        True.new
+        BooleanLiteral.new(value: true)
       end
 
       def parse_false
-        False.new
+        BooleanLiteral.new(value: false)
       end
 
       def parse_parenthetical

--- a/lib/javascript/parser.rb
+++ b/lib/javascript/parser.rb
@@ -12,6 +12,7 @@ module Javascript
   PropertyDefinition  = Struct.new(:name, :value, keyword_init: true)
   Return              = Struct.new(:expression)
   StatementList       = Struct.new(:statements)
+  StringLiteral       = Struct.new(:value)
   UnaryOperation      = Struct.new(:operator, :operand)
   VariableDeclaration = Struct.new(:name, :value)
   VariableStatement   = Struct.new(:declarations, keyword_init: true)
@@ -280,7 +281,7 @@ module Javascript
       end
 
       def parse_string_literal
-        String.new(tokenizer.current_token.literal)
+        StringLiteral.new(tokenizer.current_token.literal)
       end
 
       def parse_number_literal

--- a/lib/javascript/parser.rb
+++ b/lib/javascript/parser.rb
@@ -7,6 +7,7 @@ module Javascript
   FunctionDefinition  = Struct.new(:name, :parameters, :body)
   Identifier          = Struct.new(:name)
   If                  = Struct.new(:condition, :consequent, :alternative)
+  NumberLiteral       = Struct.new(:value)
   ObjectLiteral       = Struct.new(:properties)
   Parenthetical       = Struct.new(:expression)
   PropertyDefinition  = Struct.new(:name, :value, keyword_init: true)
@@ -285,7 +286,7 @@ module Javascript
       end
 
       def parse_number_literal
-        Number.new(tokenizer.current_token.literal)
+        NumberLiteral.new(tokenizer.current_token.literal)
       end
 
       def parse_object_literal


### PR DESCRIPTION
What the parser and the interpreter do are different (there’s a clue that they’re separate classes). The parser shouldn’t be care, or indeed know, about runtime concerns.

Besides, we can’t return a runtime representation of an object from the parser, because we need to evaluate the values. So we’ll always have an `ObjectLiteral`. Not having equivalent other literals seems a bit odd.