### PR TITLE
Multiple grammars

### DIFF
--- a/lib/javascript/grammar.rb
+++ b/lib/javascript/grammar.rb
@@ -4,7 +4,6 @@ module Javascript
     IDENTIFIER_CHARACTER = /#{START_OF_IDENTIFIER}|\p{Mn}|\p{Mc}|\p{Nd}|\p{Pc}|\u200c|\u200d/
     KEYWORDS = %w( break const continue debugger do else false function if new null return throw true typeof var void while with )
 
-
     def initialize(scanner)
       @scanner = scanner
     end
@@ -15,10 +14,17 @@ module Javascript
       when scanner.scan("/*")                then tokenize_block_comment
       when scanner.scan(START_OF_IDENTIFIER) then tokenize_identifier
       when scanner.scan($/)                  then :line_break
-      when scanner.scan(/\s+/)               then :whitespace
       when scanner.eos?                      then :end_of_file
       else
         :unknown
+      end
+    end
+
+    def skip_whitespace(preserve_line_breaks: false)
+      if preserve_line_breaks
+        scanner.skip(/[^\S\r\n]+/)
+      else
+        scanner.skip(/\s+/)
       end
     end
 

--- a/lib/javascript/grammar.rb
+++ b/lib/javascript/grammar.rb
@@ -1,6 +1,9 @@
 module Javascript
   class Grammar
     START_OF_IDENTIFIER = /\p{L}|_|\$/
+    IDENTIFIER_CHARACTER = /#{START_OF_IDENTIFIER}|\p{Mn}|\p{Mc}|\p{Nd}|\p{Pc}|\u200c|\u200d/
+    KEYWORDS = %w( break const continue debugger do else false function if new null return throw true typeof var void while with )
+
 
     def initialize(scanner)
       @scanner = scanner
@@ -11,37 +14,11 @@ module Javascript
       when scanner.scan("//")                then tokenize_inline_comment
       when scanner.scan("/*")                then tokenize_block_comment
       when scanner.scan(START_OF_IDENTIFIER) then tokenize_identifier
-      when scanner.scan(/\d/)                then tokenize_numeric
-      when scanner.scan(/"|'/)               then tokenize_string
-      when scanner.scan(".")                 then tokenize_dot
-      when scanner.scan("&")                 then tokenize_ampersand
-      when scanner.scan("|")                 then tokenize_pipe
-      when scanner.scan("=")                 then tokenize_equals
-      when scanner.scan("+")                 then tokenize_plus
-      when scanner.scan("-")                 then tokenize_minus
-      when scanner.scan("*")                 then tokenize_star
-      when scanner.scan("/")                 then tokenize_forward_slash
-      when scanner.scan("!")                 then tokenize_exclamation_mark
-      when scanner.scan("<")                 then tokenize_left_caret
-      when scanner.scan(">")                 then tokenize_right_caret
-      when scanner.scan("^")                 then tokenize_up_caret
-      when scanner.scan("%")                 then tokenize_percent
-      when scanner.scan("?")                 then tokenize_question_mark
-      when scanner.scan(",")                 then :comma
-      when scanner.scan("~")                 then :tilde
-      when scanner.scan("(")                 then :opening_bracket
-      when scanner.scan(")")                 then :closing_bracket
-      when scanner.scan("{")                 then :opening_brace
-      when scanner.scan("}")                 then :closing_brace
-      when scanner.scan("[")                 then :opening_square_bracket
-      when scanner.scan("]")                 then :closing_square_bracket
-      when scanner.scan(":")                 then :colon
-      when scanner.scan(";")                 then :semicolon
       when scanner.scan($/)                  then :line_break
       when scanner.scan(/\s+/)               then :whitespace
       when scanner.eos?                      then :end_of_file
       else
-        raise SyntaxError, "Unrecognised character: #{scanner.getch.inspect}"
+        :unknown
       end
     end
 
@@ -67,9 +44,6 @@ module Javascript
       end
 
 
-      IDENTIFIER_CHARACTER = /#{START_OF_IDENTIFIER}|\p{Mn}|\p{Mc}|\p{Nd}|\p{Pc}|\u200c|\u200d/
-      KEYWORDS = %w( break const continue debugger do else false function if new null return throw true typeof var void while with )
-
       def tokenize_identifier
         scanner.unscan
 
@@ -79,219 +53,6 @@ module Javascript
           :keyword
         else
           :identifier
-        end
-      end
-
-      def tokenize_numeric
-        scanner.unscan
-
-        number = consume_number
-
-        if scanner.scan(START_OF_IDENTIFIER) || scanner.scan(/\d/) || scanner.scan(".")
-          raise SyntaxError
-        else
-          [ :number, number ]
-        end
-      end
-
-      def consume_number
-        NumberConsumer.new(scanner).consume_number
-      end
-
-      def tokenize_string
-        quotation_mark = scanner.matched
-        string = ::String.new
-
-        loop do
-          case
-          when scanner.scan(quotation_mark)
-            break
-          when scanner.eos?
-            raise SyntaxError
-          when scanner.scan(/\R/)
-            raise SyntaxError
-          when scanner.scan("\\")
-            string << consume_escape_sequence unless scanner.scan(/\R/)
-          else
-            string << scanner.getch
-          end
-        end
-
-        [ :string, string ]
-      end
-
-      def consume_escape_sequence
-        case
-        when scanner.scan(/n|r|t|b|f|v/) then consume_escaped_character
-        when scanner.scan("u")           then consume_unicode_escape
-        when scanner.scan("x")           then consume_hex_escape
-        when scanner.scan(/[0-7]/)       then consume_octal_escape
-        else
-          scanner.getch
-        end
-      end
-
-      def consume_escaped_character
-        %("\\#{scanner.matched}").undump
-      end
-
-      def consume_unicode_escape
-        if scanner.scan(/(\h{4})/) || scanner.scan(/{(\h{1,6})}/)
-          scanner.captures[0].to_i(16).chr("UTF-8")
-        else
-          raise SyntaxError
-        end
-      end
-
-      def consume_hex_escape
-        if scanner.scan(/\h{2}/)
-          scanner.matched.to_i(16).chr("UTF-8")
-        else
-          raise SyntaxError
-        end
-      end
-
-      def consume_octal_escape
-        ::String.new.tap do |octal|
-          octal << scanner.matched
-
-          case scanner.matched.to_i
-          when 0..3
-            octal << scanner.scan(/[0-7]{1,2}/).to_s
-          when 4..7
-            octal << scanner.scan(/[0-7]{1}/).to_s
-          end
-        end.to_i(8).chr("UTF-8")
-      end
-
-      def tokenize_dot
-        case
-       when scanner.peek(1).match?(/\d/)
-          tokenize_numeric
-       when scanner.scan("..")
-          :dot_dot_dot
-        else
-          :dot
-        end
-      end
-
-      def tokenize_ampersand
-        if scanner.scan("&")
-          tokenize_optional_equals(:ampersand_ampersand)
-        else
-          tokenize_optional_equals(:ampersand)
-        end
-      end
-
-      def tokenize_pipe
-        if scanner.scan("|")
-          tokenize_optional_equals(:pipe_pipe)
-        else
-          tokenize_optional_equals(:pipe)
-        end
-      end
-
-      def tokenize_equals
-        case
-        when scanner.scan("==")
-          :equals_equals_equals
-        when scanner.scan("=")
-          :equals_equals
-        else
-          :equals
-        end
-      end
-
-      def tokenize_plus
-        if scanner.scan("+")
-          :plus_plus
-        else
-          tokenize_optional_equals(:plus)
-        end
-      end
-
-      def tokenize_minus
-        if scanner.scan("-")
-          :minus_minus
-        else
-          tokenize_optional_equals(:minus)
-        end
-      end
-
-      def tokenize_star
-        if scanner.scan("*")
-          tokenize_optional_equals(:star_star)
-        else
-          tokenize_optional_equals(:star)
-        end
-      end
-
-      def tokenize_forward_slash
-        tokenize_optional_equals(:forward_slash)
-      end
-
-      def tokenize_exclamation_mark
-        case
-        when scanner.scan("==")
-          :exclamation_equals_equals
-        when scanner.scan("=")
-          :exclamation_equals
-        else
-          :exclamation_mark
-        end
-      end
-
-      def tokenize_left_caret
-        if scanner.scan("<")
-          tokenize_optional_equals(:left_caret_caret)
-        else
-          tokenize_optional_equals(:left_caret)
-        end
-      end
-
-      def tokenize_right_caret
-        case
-        when scanner.scan(">>")
-          tokenize_optional_equals(:right_caret_caret_caret)
-        when scanner.scan(">")
-          tokenize_optional_equals(:right_caret_caret)
-        else
-          tokenize_optional_equals(:right_caret)
-        end
-      end
-
-      def tokenize_up_caret
-        tokenize_optional_equals(:up_caret)
-      end
-
-      def tokenize_percent
-        tokenize_optional_equals(:percent)
-      end
-      
-      def tokenize_question_mark
-        if scanner.scan(".")
-          tokenize_question_mark_dot
-        else
-          :question_mark
-        end
-      end
-      
-      def tokenize_question_mark_dot
-        case scanner.peek(1)
-        when "(", "[", START_OF_IDENTIFIER
-          :question_mark_dot
-        else
-          scanner.unscan
-          :question_mark
-        end
-      end
-
-
-      def tokenize_optional_equals(type)
-        if scanner.scan("=")
-          :"#{type}_equals"
-        else
-          type
         end
       end
   end

--- a/lib/javascript/grammar.rb
+++ b/lib/javascript/grammar.rb
@@ -11,8 +11,8 @@ module Javascript
     def next_token
       case
       when scanner.scan(START_OF_IDENTIFIER) then tokenize_identifier
+      when scanner.scan(/\s*\z/)             then :end_of_file
       when scanner.scan($/)                  then :line_break
-      when scanner.eos?                      then :end_of_file
       else
         :unknown
       end

--- a/lib/javascript/grammar/expression/infix_grammar.rb
+++ b/lib/javascript/grammar/expression/infix_grammar.rb
@@ -9,6 +9,8 @@ module Javascript
     ASSIGNMENT_OPERATOR = Regexp.union(ASSIGNMENT_OPERATORS.sort_by(&:length).reverse)
 
     def next_token
+      skip_whitespace(preserve_line_breaks: scanner.match?(/\s*#{UNARY_OPERATOR}/))
+
       case
       when scanner.scan("//")                then tokenize_inline_comment
       when scanner.scan("/*")                then tokenize_block_comment

--- a/lib/javascript/grammar/expression/infix_grammar.rb
+++ b/lib/javascript/grammar/expression/infix_grammar.rb
@@ -12,8 +12,6 @@ module Javascript
       skip_whitespace(preserve_line_breaks: scanner.match?(/\s*#{UNARY_OPERATOR}/))
 
       case
-      when scanner.scan("//")                then tokenize_inline_comment
-      when scanner.scan("/*")                then tokenize_block_comment
       when scanner.scan("=")                 then tokenize_equals
       when scanner.scan("?")                 then tokenize_question_mark
       when scanner.scan(ASSIGNMENT_OPERATOR) then :assignment_operator

--- a/lib/javascript/grammar/expression/infix_grammar.rb
+++ b/lib/javascript/grammar/expression/infix_grammar.rb
@@ -1,0 +1,58 @@
+module Javascript
+  class Grammar::Expression::InfixGrammar < Grammar
+    BINARY_OPERATORS     = %w( && || + - * / ** % == === != !== < <= > >= << >> >>> & | ^ ~ , )
+    UNARY_OPERATORS      = %w( ++ -- )
+    ASSIGNMENT_OPERATORS = %w( = += -= *= /= **= *= %= <<= >>= >>>= &= |= ^= &&= ||= )
+
+    BINARY_OPERATOR     = Regexp.union(BINARY_OPERATORS.sort_by(&:length).reverse)
+    UNARY_OPERATOR      = Regexp.union(UNARY_OPERATORS.sort_by(&:length).reverse)
+    ASSIGNMENT_OPERATOR = Regexp.union(ASSIGNMENT_OPERATORS.sort_by(&:length).reverse)
+
+    def next_token
+      case
+      when scanner.scan("//")                then tokenize_inline_comment
+      when scanner.scan("/*")                then tokenize_block_comment
+      when scanner.scan("=")                 then tokenize_equals
+      when scanner.scan("?")                 then tokenize_question_mark
+      when scanner.scan(ASSIGNMENT_OPERATOR) then :assignment_operator
+      when scanner.scan(UNARY_OPERATOR)      then :unary_operator
+      when scanner.scan(BINARY_OPERATOR)     then :binary_operator
+      when scanner.scan(".")                 then :dot
+      when scanner.scan("(")                 then :opening_bracket
+      when scanner.scan(")")                 then :closing_bracket
+      when scanner.scan("[")                 then :opening_square_bracket
+      when scanner.scan("]")                 then :closing_square_bracket
+      when scanner.scan(":")                 then :colon
+      else
+        super
+      end
+    end
+
+    private
+      def tokenize_equals
+        if scanner.scan(/==?/)
+          :binary_operator
+        else
+          :assignment_operator
+        end
+      end
+
+      def tokenize_question_mark
+        if scanner.scan(".")
+          tokenize_question_mark_dot
+        else
+          :question_mark
+        end
+      end
+
+      def tokenize_question_mark_dot
+        case scanner.peek(1)
+        when "(", "[", START_OF_IDENTIFIER
+          :question_mark_dot
+        else
+          scanner.unscan
+          :question_mark
+        end
+      end
+  end
+end

--- a/lib/javascript/grammar/expression/prefix_grammar.rb
+++ b/lib/javascript/grammar/expression/prefix_grammar.rb
@@ -1,0 +1,108 @@
+module Javascript
+  class Grammar::Expression::PrefixGrammar < Grammar
+    UPDATE_OPERATOR = Regexp.union(%w( ++ -- ).sort_by(&:length).reverse)
+    UNARY_OPERATOR  = Regexp.union(%w( ! ~ + - void typeof ).sort_by(&:length).reverse)
+
+    def next_token
+      case
+      when scanner.scan(/\.?\d/)             then tokenize_numeric
+      when scanner.scan(/"|'/)               then tokenize_string
+      when scanner.scan(UPDATE_OPERATOR)     then :update_operator
+      when scanner.scan(UNARY_OPERATOR)      then :unary_operator
+      when scanner.scan(",")                 then :comma
+      when scanner.scan("(")                 then :opening_bracket
+      when scanner.scan(")")                 then :closing_bracket
+      when scanner.scan("{")                 then :opening_brace
+      when scanner.scan("}")                 then :closing_brace
+      when scanner.scan("[")                 then :opening_square_bracket
+      when scanner.scan("]")                 then :closing_square_bracket
+      when scanner.scan(":")                 then :colon
+      else
+        super
+      end
+    end
+
+    private
+      def tokenize_numeric
+        scanner.unscan
+
+        number = consume_number
+
+        if scanner.scan(START_OF_IDENTIFIER) || scanner.scan(/\d/) || scanner.scan(".")
+          raise SyntaxError
+        else
+          [ :number, number ]
+        end
+      end
+
+      def consume_number
+        Grammar::NumberConsumer.new(scanner).consume_number
+      end
+
+      def tokenize_string
+        quotation_mark = scanner.matched
+        string = ::String.new
+
+        loop do
+          case
+          when scanner.scan(quotation_mark)
+            break
+          when scanner.eos?
+            raise SyntaxError
+          when scanner.scan(/\R/)
+            raise SyntaxError
+          when scanner.scan("\\")
+            string << consume_escape_sequence unless scanner.scan(/\R/)
+          else
+            string << scanner.getch
+          end
+        end
+
+        [ :string, string ]
+      end
+
+      def consume_escape_sequence
+        case
+        when scanner.scan(/n|r|t|b|f|v/) then consume_escaped_character
+        when scanner.scan("u")           then consume_unicode_escape
+        when scanner.scan("x")           then consume_hex_escape
+        when scanner.scan(/[0-7]/)       then consume_octal_escape
+        else
+          scanner.getch
+        end
+      end
+
+      def consume_escaped_character
+        %("\\#{scanner.matched}").undump
+      end
+
+      def consume_unicode_escape
+        if scanner.scan(/(\h{4})/) || scanner.scan(/{(\h{1,6})}/)
+          scanner.captures[0].to_i(16).chr("UTF-8")
+        else
+          raise SyntaxError
+        end
+      end
+
+      def consume_hex_escape
+        if scanner.scan(/\h{2}/)
+          scanner.matched.to_i(16).chr("UTF-8")
+        else
+          raise SyntaxError
+        end
+      end
+
+      def consume_octal_escape
+        ::String.new.tap do |octal|
+          octal << scanner.matched
+
+          case scanner.matched.to_i
+          when 0..3
+            octal << scanner.scan(/[0-7]{1,2}/).to_s
+          when 4..7
+            octal << scanner.scan(/[0-7]{1}/).to_s
+          end
+        end.to_i(8).chr("UTF-8")
+      end
+  end
+end

--- a/lib/javascript/grammar/expression/prefix_grammar.rb
+++ b/lib/javascript/grammar/expression/prefix_grammar.rb
@@ -4,19 +4,21 @@ module Javascript
     UNARY_OPERATOR  = Regexp.union(%w( ! ~ + - void typeof ).sort_by(&:length).reverse)
 
     def next_token
+      skip_whitespace
+
       case
-      when scanner.scan(/\.?\d/)             then tokenize_numeric
-      when scanner.scan(/"|'/)               then tokenize_string
-      when scanner.scan(UPDATE_OPERATOR)     then :update_operator
-      when scanner.scan(UNARY_OPERATOR)      then :unary_operator
-      when scanner.scan(",")                 then :comma
-      when scanner.scan("(")                 then :opening_bracket
-      when scanner.scan(")")                 then :closing_bracket
-      when scanner.scan("{")                 then :opening_brace
-      when scanner.scan("}")                 then :closing_brace
-      when scanner.scan("[")                 then :opening_square_bracket
-      when scanner.scan("]")                 then :closing_square_bracket
-      when scanner.scan(":")                 then :colon
+      when scanner.scan(/\.?\d/)         then tokenize_numeric
+      when scanner.scan(/"|'/)           then tokenize_string
+      when scanner.scan(UPDATE_OPERATOR) then :update_operator
+      when scanner.scan(UNARY_OPERATOR)  then :unary_operator
+      when scanner.scan(",")             then :comma
+      when scanner.scan("(")             then :opening_bracket
+      when scanner.scan(")")             then :closing_bracket
+      when scanner.scan("{")             then :opening_brace
+      when scanner.scan("}")             then :closing_brace
+      when scanner.scan("[")             then :opening_square_bracket
+      when scanner.scan("]")             then :closing_square_bracket
+      when scanner.scan(":")             then :colon
       else
         super
       end

--- a/lib/javascript/grammar/statement_grammar.rb
+++ b/lib/javascript/grammar/statement_grammar.rb
@@ -1,7 +1,7 @@
 module Javascript
   class Grammar::StatementGrammar < Grammar
     def next_token
-      skip_whitespace(preserve_line_breaks: true)
+      skip_whitespace(preserve_line_breaks: @preserve_line_breaks)
 
       case
       when scanner.scan("=") then :equals
@@ -15,6 +15,14 @@ module Javascript
       else
         super
       end
+    end
+
+    def with_line_breaks
+      had_line_breaks = @preserve_line_breaks
+      @preserve_line_breaks = true
+      yield
+    ensure
+      @preserve_line_breaks = had_line_breaks
     end
   end
 end

--- a/lib/javascript/grammar/statement_grammar.rb
+++ b/lib/javascript/grammar/statement_grammar.rb
@@ -1,15 +1,17 @@
 module Javascript
   class Grammar::StatementGrammar < Grammar
     def next_token
+      skip_whitespace(preserve_line_breaks: true)
+
       case
-      when scanner.scan("=")                 then :equals
-      when scanner.scan(",")                 then :comma
-      when scanner.scan("(")                 then :opening_bracket
-      when scanner.scan(")")                 then :closing_bracket
-      when scanner.scan("{")                 then :opening_brace
-      when scanner.scan("}")                 then :closing_brace
-      when scanner.scan(":")                 then :colon
-      when scanner.scan(";")                 then :semicolon
+      when scanner.scan("=") then :equals
+      when scanner.scan(",") then :comma
+      when scanner.scan("(") then :opening_bracket
+      when scanner.scan(")") then :closing_bracket
+      when scanner.scan("{") then :opening_brace
+      when scanner.scan("}") then :closing_brace
+      when scanner.scan(":") then :colon
+      when scanner.scan(";") then :semicolon
       else
         super
       end

--- a/lib/javascript/grammar/statement_grammar.rb
+++ b/lib/javascript/grammar/statement_grammar.rb
@@ -1,0 +1,18 @@
+module Javascript
+  class Grammar::StatementGrammar < Grammar
+    def next_token
+      case
+      when scanner.scan("=")                 then :equals
+      when scanner.scan(",")                 then :comma
+      when scanner.scan("(")                 then :opening_bracket
+      when scanner.scan(")")                 then :closing_bracket
+      when scanner.scan("{")                 then :opening_brace
+      when scanner.scan("}")                 then :closing_brace
+      when scanner.scan(":")                 then :colon
+      when scanner.scan(";")                 then :semicolon
+      else
+        super
+      end
+    end
+  end
+end

--- a/lib/javascript/parser/expression_parser.rb
+++ b/lib/javascript/parser/expression_parser.rb
@@ -7,10 +7,17 @@ module Javascript
     end
 
     def parse_expression
-      expression = parse_prefix
+      expression = nil
 
-      while precedence < (current_precedence = precedence_of(parser.tokenizer.look_ahead))
-        expression = parse_infix(expression, precedence: current_precedence)
+      parser.tokenizer.with_grammar(Grammar::Expression::PrefixGrammar) do
+        expression = parse_prefix
+      end
+
+
+      parser.tokenizer.with_grammar(Grammar::Expression::InfixGrammar) do
+        while precedence < (current_precedence = precedence_of(parser.tokenizer.look_ahead))
+          expression = parse_infix(expression, precedence: current_precedence)
+        end
       end
 
       expression

--- a/lib/javascript/parser/expression_parser/infix_parser.rb
+++ b/lib/javascript/parser/expression_parser/infix_parser.rb
@@ -41,18 +41,6 @@ module Javascript
       end
 
       def parse_unary_operation
-        tokenizer.rewind
-
-        if tokenizer.consume(:line_break)
-          tokenizer.insert_semicolon
-          prefix
-        else
-          tokenizer.next_token
-          parse_update_operation
-        end
-      end
-
-      def parse_update_operation
         if prefix.is_a?(Identifier) || prefix.is_a?(PropertyAccess)
           UnaryOperation.new operator: tokenizer.current_token.value, operand: prefix, position: :postfix
         else

--- a/lib/javascript/parser/expression_parser/infix_parser.rb
+++ b/lib/javascript/parser/expression_parser/infix_parser.rb
@@ -1,10 +1,5 @@
 module Javascript
   class Parser::ExpressionParser::InfixParser
-    RIGHT_ASSOCIATIVE_OPERATORS = %w( ** )
-    LEFT_ASSOCIATIVE_OPERATORS  = %w( / * + - , % == === != !== < <= > >= << >> >>> && || & | ^ )
-    UNARY_OPERATORS             = %w( ++ -- )
-    ASSIGNMENT_OPERATORS        = %w( = += -= *= /= **= *= %= <<= >>= >>>= &= |= ^= &&= ||= )
-    
     attr_reader :prefix, :precedence
 
     def initialize(parser:, prefix:, precedence:)
@@ -13,15 +8,15 @@ module Javascript
 
     def parse_infix
       case
-      when tokenizer.consume(RIGHT_ASSOCIATIVE_OPERATORS) then parse_rightward_binary_operation
-      when tokenizer.consume(LEFT_ASSOCIATIVE_OPERATORS)  then parse_leftward_binary_operation
-      when tokenizer.consume(UNARY_OPERATORS)             then parse_unary_operation
-      when tokenizer.consume(ASSIGNMENT_OPERATORS)        then parse_assignment
-      when tokenizer.consume("?.")                        then parse_optional_chaining
-      when tokenizer.consume(".")                         then parse_property_access_with_dot
-      when tokenizer.consume("[")                         then parse_property_access_with_square_brackets
-      when tokenizer.consume("(")                         then parse_function_call
-      when tokenizer.consume("?")                         then parse_ternary
+      when tokenizer.consume("**")                 then parse_rightward_binary_operation
+      when tokenizer.consume(:binary_operator)     then parse_leftward_binary_operation
+      when tokenizer.consume(:unary_operator)      then parse_unary_operation
+      when tokenizer.consume(:assignment_operator) then parse_assignment
+      when tokenizer.consume("?.")                 then parse_optional_chaining
+      when tokenizer.consume(".")                  then parse_property_access_with_dot
+      when tokenizer.consume("[")                  then parse_property_access_with_square_brackets
+      when tokenizer.consume("(")                  then parse_function_call
+      when tokenizer.consume("?")                  then parse_ternary
       end
     end
 
@@ -78,7 +73,7 @@ module Javascript
           raise SyntaxError
         end
       end
-      
+
       def parse_optional_chaining
         case
         when tokenizer.consume("(")
@@ -108,11 +103,11 @@ module Javascript
         [].tap do |arguments|
           tokenizer.until(:closing_bracket) do
             arguments << parse_argument
-            tokenizer.consume(:comma)
+            tokenizer.consume(",")
           end
         end
       end
-      
+
       def parse_argument
         if tokenizer.consume("...")
           Spread.new parser.parse_expression(precedence: 2)

--- a/lib/javascript/parser/statement_parser.rb
+++ b/lib/javascript/parser/statement_parser.rb
@@ -131,10 +131,12 @@ module Javascript
       end
 
       def parse_throw_statement
-        if tokenizer.consume(:line_break)
-          raise SyntaxError
-        else
-          Throw.new(parser.parse_expression)
+        tokenizer.grammar.with_line_breaks do
+          if tokenizer.consume(:line_break)
+            raise SyntaxError
+          else
+            Throw.new(parser.parse_expression)
+          end
         end
       end
 
@@ -160,10 +162,12 @@ module Javascript
       end
 
       def parse_return_statement
-        if tokenizer.consume(";") || tokenizer.consume(:line_break)
-          Return.new
-        else
-          Return.new(parser.parse_expression)
+        tokenizer.grammar.with_line_breaks do
+          if tokenizer.consume(";") || tokenizer.consume(:line_break)
+            Return.new
+          else
+            Return.new(parser.parse_expression)
+          end
         end
       end
 
@@ -181,7 +185,9 @@ module Javascript
 
       def parse_expression_statement
         ExpressionStatement.new(parser.parse_expression).tap do
-          raise SyntaxError.new("Unexpected #{tokenizer.next_token.value.inspect}") unless tokenizer.consume(:semicolon) || tokenizer.consume(:end_of_file) || tokenizer.consume(:line_break)
+          tokenizer.grammar.with_line_breaks do
+            raise SyntaxError.new("Unexpected #{tokenizer.next_token.value.inspect}") unless tokenizer.consume(:semicolon) || tokenizer.consume(:end_of_file) || tokenizer.consume(:line_break)
+          end
         end
       end
   end

--- a/lib/javascript/parser/statement_parser.rb
+++ b/lib/javascript/parser/statement_parser.rb
@@ -5,24 +5,26 @@ module Javascript
     end
 
     def parse_statement
-      case
-      when tokenizer.consume("var")      then parse_var_statement
-      when tokenizer.consume("let")      then parse_let_statement_or_expression
-      when tokenizer.consume("const")    then parse_const_statement
-      when tokenizer.consume("if")       then parse_if_statement
-      when tokenizer.consume("while")    then parse_while_loop
-      when tokenizer.consume("do")       then parse_do_while_loop
-      when tokenizer.consume("break")    then parse_break_statement
-      when tokenizer.consume("continue") then parse_continue_statement
-      when tokenizer.consume("throw")    then parse_throw_statement
-      when tokenizer.consume("function") then parse_function_declaration
-      when tokenizer.consume("{")        then parse_block
-      when tokenizer.consume("return")   then parse_return_statement
-      when tokenizer.consume("with")     then parse_with_statement
-      when tokenizer.consume("debugger") then parse_debugger_statement
-      when tokenizer.consume(";")        then parse_empty_statement
-      else
-        parse_expression_statement
+      tokenizer.with_grammar(Grammar::StatementGrammar) do
+        case
+        when tokenizer.consume("var")      then parse_var_statement
+        when tokenizer.consume("let")      then parse_let_statement_or_expression
+        when tokenizer.consume("const")    then parse_const_statement
+        when tokenizer.consume("if")       then parse_if_statement
+        when tokenizer.consume("while")    then parse_while_loop
+        when tokenizer.consume("do")       then parse_do_while_loop
+        when tokenizer.consume("break")    then parse_break_statement
+        when tokenizer.consume("continue") then parse_continue_statement
+        when tokenizer.consume("throw")    then parse_throw_statement
+        when tokenizer.consume("function") then parse_function_declaration
+        when tokenizer.consume("{")        then parse_block
+        when tokenizer.consume("return")   then parse_return_statement
+        when tokenizer.consume("with")     then parse_with_statement
+        when tokenizer.consume("debugger") then parse_debugger_statement
+        when tokenizer.consume(";")        then parse_empty_statement
+        else
+          parse_expression_statement
+        end
       end
     end
 
@@ -91,7 +93,7 @@ module Javascript
       def parse_variable_declaration
         VariableDeclaration.new.tap do |declaration|
           declaration.name  = tokenizer.consume!(:identifier).value
-          declaration.value = parser.parse_expression(precedence: 2) if tokenizer.consume(:equals)
+          declaration.value = parser.parse_expression(precedence: 2) if tokenizer.consume("=")
         end
       end
 
@@ -179,7 +181,7 @@ module Javascript
 
       def parse_expression_statement
         ExpressionStatement.new(parser.parse_expression).tap do
-          raise SyntaxError.new("Unexpected #{tokenizer.next_token.value}") unless tokenizer.consume(:semicolon) || tokenizer.consume(:end_of_file) || tokenizer.consume(:line_break)
+          raise SyntaxError.new("Unexpected #{tokenizer.next_token.value.inspect}") unless tokenizer.consume(:semicolon) || tokenizer.consume(:end_of_file) || tokenizer.consume(:line_break)
         end
       end
   end

--- a/lib/javascript/tokenizer.rb
+++ b/lib/javascript/tokenizer.rb
@@ -2,7 +2,11 @@ require "strscan"
 
 module Javascript
   class Tokenizer
-    Token = Struct.new(:type, :value, :literal, :starting_position, :ending_position, keyword_init: true)
+    Token = Struct.new(:type, :raw, :literal, :starting_position, :ending_position, keyword_init: true) do
+      def value
+        raw&.strip
+      end
+    end
 
     def initialize(javascript)
       @scanner  = StringScanner.new(javascript)
@@ -96,7 +100,7 @@ module Javascript
       def advance(keep_line_breaks: false)
         tokens = []
         tokens << advance_to_next_token
-        tokens << advance_to_next_token while [:whitespace, (:line_break unless keep_line_breaks), :comment].include?(tokens.last.type)
+        tokens << advance_to_next_token while [(:line_break unless keep_line_breaks), :comment].include?(tokens.last.type)
 
         advances << Advance.new(tokens)
       end
@@ -106,7 +110,7 @@ module Javascript
           token.starting_position   = scanner.pos
           token.type, token.literal = @grammar.next_token
           token.ending_position     = scanner.pos
-          token.value               = scanner.string.byteslice(token.starting_position...token.ending_position)
+          token.raw                 = scanner.string.byteslice(token.starting_position...token.ending_position)
         end
       end
   end

--- a/lib/javascript/tokenizer.rb
+++ b/lib/javascript/tokenizer.rb
@@ -74,10 +74,6 @@ module Javascript
       end
     end
 
-    def insert_semicolon
-      scanner.string[scanner.charpos] = ";" + scanner.string[scanner.charpos]
-    end
-
     def look_ahead
       next_token.tap { rewind }
     end

--- a/lib/javascript/tokenizer.rb
+++ b/lib/javascript/tokenizer.rb
@@ -10,6 +10,22 @@ module Javascript
       @advances = []
     end
 
+    def grammar
+      @grammar.class
+    end
+
+    def grammar=(grammar)
+      @grammar = grammar.new(scanner)
+    end
+
+    def with_grammar(grammar)
+      previous_grammar = self.grammar
+      self.grammar = grammar
+      yield
+    ensure
+      self.grammar = previous_grammar
+    end
+
     def current_token
       advances.last.tokens.last
     end

--- a/lib/javascript/tokenizer.rb
+++ b/lib/javascript/tokenizer.rb
@@ -100,12 +100,14 @@ module Javascript
       def advance(keep_line_breaks: false)
         tokens = []
         tokens << advance_to_next_token
-        tokens << advance_to_next_token while [(:line_break unless keep_line_breaks), :comment].include?(tokens.last.type)
+        tokens << advance_to_next_token while [(:line_break unless keep_line_breaks)].include?(tokens.last.type)
 
         advances << Advance.new(tokens)
       end
 
       def advance_to_next_token
+        @grammar.skip_comments
+
         Token.new.tap do |token|
           token.starting_position   = scanner.pos
           token.type, token.literal = @grammar.next_token


### PR DESCRIPTION
Split the mammoth Grammar class into multiple, specialised subclasses. This resembles how, way back, we used to have a single Parser class that also needed to be carved up. It is also necessary, for example to support template-literals and regexes which have specialised tokens, and this is why I originally extracted this class.

Some highlights:

* We don’t need special handling of line breaks. We can skip them or preserve them at our choosing, when it makes sense in the grammar. And that lets us remove the (hideous) Tokenizer#insert_semicolon, as well as other regrettable code (see https://github.com/dmcge/javascript/pull/16/commits/6773a9b6e5baa5887afda76dd8ed3f5aa7d20735).

* We can (finally) have dedicated `operator` tokens, which can be different depending on which grammar you are in.

* We can simplify the implementation of each grammar. Whereas previously we had to extract a large number of methods, we can now just return a symbol in most cases.]

I started working on this after writing https://github.com/dmcge/javascript/commit/643008fc18b6df0a5b53409096abcc2f5f14e4e4. I’ve since realised [that was wrong](https://github.com/dmcge/javascript/commit/643008fc18b6df0a5b53409096abcc2f5f14e4e4#commitcomment-104227201), but I think this approach is clearly better and unblocks future work (eg, on template literals).